### PR TITLE
MySQL FDW

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM postgres:10.5
 
+# We need the mysql C client libs to link the FDW against.
+# We could install MySQL's apt repo deb package, but it's interactive, so it's easier
+# to just add the sources.list entry we want.
+RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 5072E1F5
+RUN echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-8.0" > /etc/apt/sources.list.d/mysql.list
+
 RUN apt-get update -qq && \
     apt-get install -y \
         build-essential \
@@ -15,6 +21,7 @@ RUN apt-get update -qq && \
         postgresql-server-dev-all \
         libmongoc-1.0.0 \
         libmongoc-dev \
+        libmysqlclient-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /build_scripts
@@ -23,6 +30,8 @@ RUN find /build_scripts -type f -name '*.sh' -exec chmod a+x {} \;
 
 # Mongo FDW
 RUN ./build_scripts/fdws/mongo_fdw/build_mongo_fdw.sh
+# MySQL FDW
+RUN ./build_scripts/fdws/mysql_fdw/build_mysql_fdw.sh
 
 EXPOSE 5432
 ENV POSTGRES_DB cachedb

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM postgres:10.5
 # We need the mysql C client libs to link the FDW against.
 # We could install MySQL's apt repo deb package, but it's interactive, so it's easier
 # to just add the sources.list entry we want.
-RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 5072E1F5
+RUN apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
 RUN echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-8.0" > /etc/apt/sources.list.d/mysql.list
 
+# Make sure to just get the pg10 toolchain, otherwise the extensions build against pg11
 RUN apt-get update -qq && \
     apt-get install -y \
         build-essential \
@@ -18,7 +19,7 @@ RUN apt-get update -qq && \
         pkgconf \
         autoconf \
         libtool \
-        postgresql-server-dev-all \
+        postgresql-server-dev-10 \
         libmongoc-1.0.0 \
         libmongoc-dev \
         libmysqlclient-dev \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ external databases (only mongo and postgres at the moment):
        to allow mounting of mongo databases
     * [postgres_fdw](https://www.postgresql.org/docs/10/static/postgres-fdw.html)
       to allow mounting of external postgres databases
-* Installs audit triggers for change detection
+    * [EnterpriseDB/mysql_fdw](https://github.com/EnterpriseDB/mysql_fdw.git)
+       to allow mounting of MySQL (version 8) databases
+ * Installs audit triggers for change detection
     * Creates `audit` schema
     * Configures audit triggers necessary for Splitgraph change tracking
     * Based on [2ndQuadrant/audit-trigger](https://github.com/2ndQuadrant/audit-trigger)

--- a/build_scripts/fdws/mysql_fdw/build_mysql_fdw.sh
+++ b/build_scripts/fdws/mysql_fdw/build_mysql_fdw.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo "Install mysql_fdw extension..."
+
+fatal_error() {
+    echo "Fatal:" "$@" 1>&2 ;
+    exit 1;
+}
+
+mkdir /tmp/mysql-fdw-staging || {
+    fatal_error "Failed to mkdir /tmp/mysql-fdw-staging" ;
+}
+
+
+cd /tmp/mysql-fdw-staging || {
+    fatal_error "Failed to cd /tmp/mysql-fdw-staging" ;
+}
+
+echo "Download mysql_fdw source code..."
+git clone https://github.com/EnterpriseDB/mysql_fdw.git
+cd mysql_fdw || {
+    fatal_error "Failed to cd /tmp/mysql-fdw-staging/mysql_fdw" ;
+}
+
+echo "Build mysql_fdw..."
+
+USE_PGXS=1 make && USE_PGXS=1 make install
+
+echo "Finished building mysql_fdw."
+
+echo "Cleanup mysql_fdw..."
+cd / || {
+    fatal_error "Failed to cd to / for cleanup operation" ;
+}
+
+rm -rf /tmp/mysql-fdw-staging || true

--- a/init_scripts/000_create_extensions.sql
+++ b/init_scripts/000_create_extensions.sql
@@ -1,2 +1,3 @@
 CREATE EXTENSION postgres_fdw;
 CREATE EXTENSION mongo_fdw;
+CREATE EXTENSION mysql_fdw;


### PR DESCRIPTION
Added MySQL FDW (also from EnterpriseDB, similar installation process, biggest issue was actually getting the C client libs installed) and made sure to install pg10 dev tooling (otherwise the extensions get compiled against 11).

Works on my machine™ with the test suite / sgr handler defined in the companion PR (https://github.com/splitgraph/splitgraph/pull/14)